### PR TITLE
Correct error in MeshBuilder

### DIFF
--- a/src/public/materialsystem/imesh.h
+++ b/src/public/materialsystem/imesh.h
@@ -1,4 +1,4 @@
-//==== Copyright © 1996-2005, Valve Corporation, All rights reserved. =======//
+//==== Copyright Â© 1996-2005, Valve Corporation, All rights reserved. =======//
 //
 // Purpose: 
 //
@@ -1127,10 +1127,10 @@ inline void CVertexBuilder::FastVertex( const ModelVertexDX7_t &vertex )
 	Assert( m_nCurrentVertex < m_nMaxVertexCount );
 
 	// TODO: Make this less shitty
-	__m128* v1 = (__m128*)&m_pCurrPosition;
-	__m128* v2 = ((__m128*)&m_pCurrPosition + 1);
-	__m128* v3 = ((__m128*)&m_pCurrPosition + 2);
-	__m128* v4 = ((__m128*)&m_pCurrPosition + 3);
+	__m128* v1 = (__m128*)m_pCurrPosition;
+	__m128* v2 = ((__m128*)m_pCurrPosition + 1);
+	__m128* v3 = ((__m128*)m_pCurrPosition + 2);
+	__m128* v4 = ((__m128*)m_pCurrPosition + 3);
 	*v1 = _mm_loadu_ps((float*)&vertex);
 	*v2 = _mm_loadu_ps((float*)&vertex + 4);
 	*v3 = _mm_loadu_ps((float*)&vertex + 8);
@@ -1151,10 +1151,10 @@ inline void CVertexBuilder::FastVertexSSE( const ModelVertexDX7_t &vertex )
 	Assert( m_nCurrentVertex < m_nMaxVertexCount );
 
 	// TODO: Make this less shitty
-	__m128* v1 = (__m128*)&m_pCurrPosition;
-	__m128* v2 = ((__m128*)&m_pCurrPosition + 1);
-	__m128* v3 = ((__m128*)&m_pCurrPosition + 2);
-	__m128* v4 = ((__m128*)&m_pCurrPosition + 3);
+	__m128* v1 = (__m128*)m_pCurrPosition;
+	__m128* v2 = ((__m128*)m_pCurrPosition + 1);
+	__m128* v3 = ((__m128*)m_pCurrPosition + 2);
+	__m128* v4 = ((__m128*)m_pCurrPosition + 3);
 	*v1 = _mm_loadu_ps((float*)&vertex);
 	*v2 = _mm_loadu_ps((float*)&vertex + 4);
 	*v3 = _mm_loadu_ps((float*)&vertex + 8);
@@ -1175,15 +1175,15 @@ inline void CVertexBuilder::FastVertexAVX(const ModelVertexDX7_t &vertex)
 	Assert(m_nCurrentVertex < m_nMaxVertexCount);
 
 #ifdef _USE_AVX
-	__m256* v1 = (__m256*)&m_pCurrPosition;
-	__m256* v2 = ((__m256*)&m_pCurrPosition + 1);
+	__m256* v1 = (__m256*)m_pCurrPosition;
+	__m256* v2 = ((__m256*)m_pCurrPosition + 1);
 	*v1 = _mm256_loadu_ps((float*)&vertex);
 	*v2 = _mm256_loadu_ps((float*)&vertex + 4);
 #else
-	__m128* v1 = (__m128*)&m_pCurrPosition;
-	__m128* v2 = ((__m128*)&m_pCurrPosition + 1);
-	__m128* v3 = ((__m128*)&m_pCurrPosition + 2);
-	__m128* v4 = ((__m128*)&m_pCurrPosition + 3);
+	__m128* v1 = (__m128*)m_pCurrPosition;
+	__m128* v2 = ((__m128*)m_pCurrPosition + 1);
+	__m128* v3 = ((__m128*)m_pCurrPosition + 2);
+	__m128* v4 = ((__m128*)m_pCurrPosition + 3);
 	*v1 = _mm_loadu_ps((float*)&vertex);
 	*v2 = _mm_loadu_ps((float*)&vertex + 4);
 	*v3 = _mm_loadu_ps((float*)&vertex + 8);
@@ -1227,10 +1227,10 @@ inline void CVertexBuilder::FastVertex( const ModelVertexDX8_t &vertex )
 	Assert( m_nCurrentVertex < m_nMaxVertexCount );
 
 	// TODO: Make this less shitty
-	__m128* v1 = (__m128*)&m_pCurrPosition;
-	__m128* v2 = ((__m128*)&m_pCurrPosition + 1);
-	__m128* v3 = ((__m128*)&m_pCurrPosition + 2);
-	__m128* v4 = ((__m128*)&m_pCurrPosition + 3);
+	__m128* v1 = (__m128*)m_pCurrPosition;
+	__m128* v2 = ((__m128*)m_pCurrPosition + 1);
+	__m128* v3 = ((__m128*)m_pCurrPosition + 2);
+	__m128* v4 = ((__m128*)m_pCurrPosition + 3);
 	*v1 = _mm_loadu_ps((float*)&vertex);
 	*v2 = _mm_loadu_ps((float*)&vertex + 4);
 	*v3 = _mm_loadu_ps((float*)&vertex + 8);
@@ -1251,10 +1251,10 @@ inline void CVertexBuilder::FastVertexSSE( const ModelVertexDX8_t &vertex )
 	Assert( m_nCurrentVertex < m_nMaxVertexCount );
 
 	// TODO: Make this less shitty
-	__m128* v1 = (__m128*)&m_pCurrPosition;
-	__m128* v2 = ((__m128*)&m_pCurrPosition + 1);
-	__m128* v3 = ((__m128*)&m_pCurrPosition + 2);
-	__m128* v4 = ((__m128*)&m_pCurrPosition + 3);
+	__m128* v1 = (__m128*)m_pCurrPosition;
+	__m128* v2 = ((__m128*)m_pCurrPosition + 1);
+	__m128* v3 = ((__m128*)m_pCurrPosition + 2);
+	__m128* v4 = ((__m128*)m_pCurrPosition + 3);
 	*v1 = _mm_loadu_ps((float*)&vertex);
 	*v2 = _mm_loadu_ps((float*)&vertex + 4);
 	*v3 = _mm_loadu_ps((float*)&vertex + 8);
@@ -1274,8 +1274,8 @@ inline void CVertexBuilder::FastVertexAVX(const ModelVertexDX8_t &vertex)
 	Assert(m_CompressionType == VERTEX_COMPRESSION_NONE); // FIXME: support compressed verts if needed
 	Assert(m_nCurrentVertex < m_nMaxVertexCount);
 
-	__m256* v1 = (__m256*)&m_pCurrPosition;
-	__m256* v2 = ((__m256*)&m_pCurrPosition + 1);
+	__m256* v1 = (__m256*)m_pCurrPosition;
+	__m256* v2 = ((__m256*)m_pCurrPosition + 1);
 	*v1 = _mm256_loadu_ps((float*)&vertex);
 	*v2 = _mm256_loadu_ps((float*)&vertex + 4);
 


### PR DESCRIPTION
`m_pCurrentPosition` was not treated as a pointer when it should have been.
This might fix the vertex bugs on models.